### PR TITLE
Добавлен REST метод проверки доступа пользователя к каналу

### DIFF
--- a/config/web.php
+++ b/config/web.php
@@ -49,7 +49,8 @@ $config = [
             'enablePrettyUrl' => true,
             'showScriptName' => false,
             'rules' => [
-                ['class' => 'yii\\rest\\UrlRule', 'controller' => ['telegram-user', 'telegram-channel', 'user-channel-access']],
+                ['class' => 'yii\\rest\\UrlRule', 'controller' => ['telegram-user', 'telegram-channel']],
+                ['class' => 'yii\\rest\\UrlRule', 'controller' => ['user-channel-access'], 'extraPatterns' => ['POST verify' => 'verify']],
             ],
         ],
     ],

--- a/controllers/UserChannelAccessController.php
+++ b/controllers/UserChannelAccessController.php
@@ -2,9 +2,50 @@
 
 namespace app\controllers;
 
+use Yii;
 use yii\rest\ActiveController;
+use app\models\TelegramChannel;
+use app\models\TelegramUser;
+use app\models\UserChannelAccess;
 
 class UserChannelAccessController extends ActiveController
 {
-    public $modelClass = \app\models\UserChannelAccess::class;
+    public $modelClass = UserChannelAccess::class;
+
+    public function actionVerify()
+    {
+        $channelId = Yii::$app->request->getBodyParam('chat_id');
+        $userChatId = Yii::$app->request->getBodyParam('user_id');
+        $channelName = Yii::$app->request->getBodyParam('channel_name');
+
+        if ($channelId === null || $userChatId === null || $channelName === null) {
+            Yii::$app->response->statusCode = 400;
+            return ['error' => 'chat_id, user_id и channel_name обязательны'];
+        }
+
+        $channel = TelegramChannel::findOne(['channel_id' => $channelId]);
+        if ($channel === null) {
+            $channel = new TelegramChannel([
+                'channel_id' => $channelId,
+                'channel_name' => $channelName,
+            ]);
+            $channel->save();
+        }
+
+        $user = TelegramUser::findOne(['chat_id' => $userChatId]);
+        if ($user === null) {
+            $user = new TelegramUser([
+                'chat_id' => $userChatId,
+            ]);
+            $user->save();
+        }
+
+        $access = UserChannelAccess::findOne([
+            'user_id' => $user->id,
+            'channel_id' => $channel->id,
+            'has_access' => 1,
+        ]);
+
+        return ['has_access' => $access !== null];
+    }
 }


### PR DESCRIPTION
## Summary
- Добавлен экшен `verify` для проверки доступа пользователя к каналу и создания отсутствующих записей
- Настроено правило маршрутизации для нового экшена

## Testing
- `php -l controllers/UserChannelAccessController.php`
- `php -l config/web.php`
- `composer install` *(ошибка 403 при обращении к GitHub)*
- `./vendor/bin/codecept run` *(файл не найден из-за незавершённой установки зависимостей)*

------
https://chatgpt.com/codex/tasks/task_b_68c18d95c3408326bb0e425214f8f999