### PR TITLE
Исправлен алгоритм проверки доступа к каналу

### DIFF
--- a/controllers/UserChannelAccessController.php
+++ b/controllers/UserChannelAccessController.php
@@ -14,28 +14,28 @@ class UserChannelAccessController extends ActiveController
 
     public function actionVerify()
     {
-        $channelId = Yii::$app->request->getBodyParam('chat_id');
-        $userChatId = Yii::$app->request->getBodyParam('user_id');
+        $chatId = Yii::$app->request->getBodyParam('chat_id');
+        $telegramUserId = Yii::$app->request->getBodyParam('user_id');
         $channelName = Yii::$app->request->getBodyParam('channel_name');
 
-        if ($channelId === null || $userChatId === null || $channelName === null) {
+        if ($chatId === null || $telegramUserId === null || $channelName === null) {
             Yii::$app->response->statusCode = 400;
             return ['error' => 'chat_id, user_id и channel_name обязательны'];
         }
 
-        $channel = TelegramChannel::findOne(['channel_id' => $channelId]);
+        $channel = TelegramChannel::findOne(['channel_name' => $channelName]);
         if ($channel === null) {
             $channel = new TelegramChannel([
-                'channel_id' => $channelId,
+                'channel_id' => $channelName,
                 'channel_name' => $channelName,
             ]);
             $channel->save();
         }
 
-        $user = TelegramUser::findOne(['chat_id' => $userChatId]);
+        $user = TelegramUser::findOne(['chat_id' => $telegramUserId]);
         if ($user === null) {
             $user = new TelegramUser([
-                'chat_id' => $userChatId,
+                'chat_id' => $telegramUserId,
             ]);
             $user->save();
         }
@@ -43,9 +43,20 @@ class UserChannelAccessController extends ActiveController
         $access = UserChannelAccess::findOne([
             'user_id' => $user->id,
             'channel_id' => $channel->id,
-            'has_access' => 1,
+            'chat_id' => $chatId,
         ]);
 
-        return ['has_access' => $access !== null];
+        if ($access === null) {
+            $access = new UserChannelAccess([
+                'user_id' => $user->id,
+                'channel_id' => $channel->id,
+                'chat_id' => $chatId,
+                'has_access' => 0,
+            ]);
+            $access->save();
+            return ['has_access' => false, 'message' => 'Доступ запрещён'];
+        }
+
+        return ['has_access' => (bool)$access->has_access];
     }
 }

--- a/migrations/m250910_125834_create_telegram_tables.php
+++ b/migrations/m250910_125834_create_telegram_tables.php
@@ -34,6 +34,7 @@ public function safeUp()
         'id' => $this->primaryKey(),
         'user_id' => $this->integer()->notNull(),
         'channel_id' => $this->integer()->notNull(),
+        'chat_id' => $this->string(255)->notNull(),
         'has_access' => $this->boolean()->defaultValue(false),
         'granted_at' => $this->timestamp(),
         'created_at' => $this->timestamp()->defaultExpression('CURRENT_TIMESTAMP'),
@@ -60,9 +61,9 @@ public function safeUp()
     );
 
     $this->createIndex(
-        'idx_user_channel_unique',
+        'idx_user_channel_chat_unique',
         'user_channel_access',
-        ['user_id', 'channel_id'],
+        ['user_id', 'channel_id', 'chat_id'],
         true
     );
 }

--- a/models/UserChannelAccess.php
+++ b/models/UserChannelAccess.php
@@ -10,6 +10,7 @@ use Yii;
  * @property int $id
  * @property int $user_id
  * @property int $channel_id
+ * @property string $chat_id
  * @property int|null $has_access
  * @property string|null $granted_at
  * @property string|null $created_at
@@ -35,10 +36,11 @@ class UserChannelAccess extends \yii\db\ActiveRecord
         return [
             [['granted_at'], 'default', 'value' => null],
             [['has_access'], 'default', 'value' => 0],
-            [['user_id', 'channel_id'], 'required'],
+            [['user_id', 'channel_id', 'chat_id'], 'required'],
             [['user_id', 'channel_id', 'has_access'], 'integer'],
             [['granted_at', 'created_at'], 'safe'],
-            [['user_id', 'channel_id'], 'unique', 'targetAttribute' => ['user_id', 'channel_id']],
+            [['chat_id'], 'string', 'max' => 255],
+            [['user_id', 'channel_id', 'chat_id'], 'unique', 'targetAttribute' => ['user_id', 'channel_id', 'chat_id']],
             [['channel_id'], 'exist', 'skipOnError' => true, 'targetClass' => TelegramChannel::class, 'targetAttribute' => ['channel_id' => 'id']],
             [['user_id'], 'exist', 'skipOnError' => true, 'targetClass' => TelegramUser::class, 'targetAttribute' => ['user_id' => 'id']],
         ];
@@ -53,6 +55,7 @@ class UserChannelAccess extends \yii\db\ActiveRecord
             'id' => 'ID',
             'user_id' => 'User ID',
             'channel_id' => 'Channel ID',
+            'chat_id' => 'Chat ID',
             'has_access' => 'Has Access',
             'granted_at' => 'Granted At',
             'created_at' => 'Created At',


### PR DESCRIPTION
## Summary
- Исправлена логика верификации доступа пользователя к каналу: поиск канала по имени, учёт chat_id, создание записи доступа при отсутствии
- Добавлено поле `chat_id` в модель и миграцию user_channel_access

## Testing
- `composer install` *(failed: Failed to download yiisoft/yii2-composer: CONNECT tunnel failed, response 403)*
- `vendor/bin/codecept run` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c2ae67e0a48326bc2adcc47bff321f