### PR TITLE
Fix user and access creation in verification

### DIFF
--- a/controllers/UserChannelAccessController.php
+++ b/controllers/UserChannelAccessController.php
@@ -15,12 +15,11 @@ class UserChannelAccessController extends ActiveController
     public function actionVerify()
     {
         $chatId = Yii::$app->request->getBodyParam('chat_id');
-        $telegramUserId = Yii::$app->request->getBodyParam('user_id');
         $channelName = Yii::$app->request->getBodyParam('channel_name');
 
-        if ($chatId === null || $telegramUserId === null || $channelName === null) {
+        if ($chatId === null || $channelName === null) {
             Yii::$app->response->statusCode = 400;
-            return ['error' => 'chat_id, user_id и channel_name обязательны'];
+            return ['error' => 'chat_id и channel_name обязательны'];
         }
 
         $channel = TelegramChannel::findOne(['channel_name' => $channelName]);
@@ -32,10 +31,10 @@ class UserChannelAccessController extends ActiveController
             $channel->save();
         }
 
-        $user = TelegramUser::findOne(['chat_id' => $telegramUserId]);
+        $user = TelegramUser::findOne(['chat_id' => $chatId]);
         if ($user === null) {
             $user = new TelegramUser([
-                'chat_id' => $telegramUserId,
+                'chat_id' => $chatId,
             ]);
             $user->save();
         }


### PR DESCRIPTION
## Summary
- ensure verification uses `chat_id` to find/create Telegram users
- require only `chat_id` and `channel_name` in verification request

## Testing
- `composer install` *(fails: requires GitHub token)*
- `./vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68c2bf82b2348326858fb33426a908e0